### PR TITLE
Fix incorrect updating fileRowCount when skipping rowGroup

### DIFF
--- a/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/BlockMetadata.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/BlockMetadata.java
@@ -15,7 +15,7 @@ package io.trino.parquet.metadata;
 
 import java.util.List;
 
-public record BlockMetadata(long rowCount, List<ColumnChunkMetadata> columns)
+public record BlockMetadata(long fileRowCountOffset, long rowCount, List<ColumnChunkMetadata> columns)
 {
     public long getStartingPos()
     {

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/ParquetMetadata.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/metadata/ParquetMetadata.java
@@ -103,8 +103,14 @@ public class ParquetMetadata
         MessageType messageType = readParquetSchema(schema);
         List<BlockMetadata> blocks = new ArrayList<>();
         List<RowGroup> rowGroups = parquetMetadata.getRow_groups();
+
+        long fileRowCount = 0;
+
         if (rowGroups != null) {
             for (RowGroup rowGroup : rowGroups) {
+                long fileRowCountOffset = fileRowCount;
+                fileRowCount += rowGroup.getNum_rows(); // Update fileRowCount for all row groups
+
                 if (rowGroup.isSetFile_offset()) {
                     long rowGroupStart = rowGroup.getFile_offset();
                     boolean splitContainsRowGroup = splitStart <= rowGroupStart && rowGroupStart < splitStart + splitLength;
@@ -146,7 +152,7 @@ public class ParquetMetadata
                     column.setBloomFilterOffset(metaData.bloom_filter_offset);
                     columnMetadataBuilder.add(column);
                 }
-                blocks.add(new BlockMetadata(rowGroup.getNum_rows(), columnMetadataBuilder.build()));
+                blocks.add(new BlockMetadata(fileRowCountOffset, rowGroup.getNum_rows(), columnMetadataBuilder.build()));
             }
         }
 

--- a/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
+++ b/lib/trino-parquet/src/main/java/io/trino/parquet/predicate/PredicateUtils.java
@@ -193,7 +193,6 @@ public final class PredicateUtils
             ParquetReaderOptions options)
             throws IOException
     {
-        long fileRowCount = 0;
         ImmutableList.Builder<RowGroupInfo> rowGroupInfoBuilder = ImmutableList.builder();
         for (BlockMetadata block : parquetMetadata.getBlocks(splitStart, splitLength)) {
             long blockStart = block.getStartingPos();
@@ -215,12 +214,11 @@ public final class PredicateUtils
                             bloomFilterStore,
                             timeZone,
                             domainCompactionThreshold)) {
-                        rowGroupInfoBuilder.add(new RowGroupInfo(columnsMetadata, fileRowCount, columnIndex));
+                        rowGroupInfoBuilder.add(new RowGroupInfo(columnsMetadata, block.fileRowCountOffset(), columnIndex));
                         break;
                     }
                 }
             }
-            fileRowCount += block.rowCount();
         }
         return rowGroupInfoBuilder.build();
     }

--- a/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
+++ b/lib/trino-parquet/src/test/java/io/trino/parquet/writer/TestParquetWriter.java
@@ -402,6 +402,7 @@ public class TestParquetWriter
         List<BlockMetadata> blocks = parquetMetadata.getBlocks();
         assertThat(blocks.size()).isGreaterThan(1);
 
+        long fileRowCountOffset = 0;
         List<RowGroup> rowGroups = parquetMetadata.getParquetMetadata().getRow_groups();
         assertThat(rowGroups.size()).isEqualTo(blocks.size());
         for (int rowGroupIndex = 0; rowGroupIndex < rowGroups.size(); rowGroupIndex++) {
@@ -409,6 +410,8 @@ public class TestParquetWriter
             assertThat(rowGroup.isSetFile_offset()).isTrue();
             BlockMetadata blockMetadata = blocks.get(rowGroupIndex);
             assertThat(blockMetadata.getStartingPos()).isEqualTo(rowGroup.getFile_offset());
+            assertThat(blockMetadata.fileRowCountOffset()).isEqualTo(fileRowCountOffset);
+            fileRowCountOffset += rowGroup.getNum_rows();
         }
     }
 


### PR DESCRIPTION
When filtering row groups based on split boundaries in `ParquetMetadata.getBlocks()`, we need to maintain an accurate cumulative row count even for skipped row groups

(cherry picked from commit 1df7d666af64fa8887a2c637633c409439d92d2c)

<!-- Thank you for submitting a pull request! Find more information 
at https://trino.io/development/process.html, 
at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md 
and contact us on #core-dev in Slack. -->
<!-- Provide an overview for maintainers and reviewers. -->
## Description



<!-- Provide details that help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues



<!-- Mark the appropriate option with an (x). Propose a release note if you can.
More info at https://trino.io/development/process#release-note -->
## Release notes

( ) This is not user-visible or is docs only, and no release notes are required.
( ) Release notes are required. Please propose a release note for me.
( ) Release notes are required, with the following suggested text:

```markdown
## Section
* Fix some things. ({issue}`issuenumber`)
```
